### PR TITLE
Setting up the Home Route

### DIFF
--- a/app/adapters/album.js
+++ b/app/adapters/album.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+import ENV from 'kate-spotify/config/environment';
+
+export default ApplicationAdapter.extend({
+  urlForFindAll() {
+    return 'https://api.spotify.com/v1/browse/new-releases';
+  },
+  headers: {
+    Authorization: `Bearer ${ENV.AUTH_KEY}`
+  }
+});

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,4 +1,6 @@
 import DS from 'ember-data';
 import AdapterFetch from 'ember-fetch/mixins/adapter-fetch';
 
-export default DS.RESTAdapter.extend(AdapterFetch, {});
+export default DS.RESTAdapter.extend(AdapterFetch, {
+  host: 'https://api.spotify.com/v1'
+});

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -1,31 +1,8 @@
 import Route from '@ember/routing/route';
-import fetch from 'fetch';
-import ENV from 'kate-spotify/config/environment';
 
 export default Route.extend({
   model() {
-    const headers = {
-      headers: {
-        Authorization: `Bearer ${ENV.AUTH_KEY}`
-      }
-    };
-
-    const payload = fetch(
-      'https://api.spotify.com/v1/browse/new-releases',
-      headers
-    )
-      .then(function(response) {
-        const data = response.json();
-        return data;
-      })
-      .then(data => {
-        const { albums } = data;
-        const serializedData = { albums: albums.items };
-        this.get('store').pushPayload(serializedData);
-        return serializedData;
-      });
-
-    return payload;
+    return this.store.findAll('album');
     // return [
     // {
     //   track: {

--- a/app/serializers/album.js
+++ b/app/serializers/album.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  normalizeFindAllResponse() {
+    const data = this._super();
+  }
+});

--- a/tests/unit/adapters/album-test.js
+++ b/tests/unit/adapters/album-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:album', 'Unit | Adapter | album', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/serializers/album-test.js
+++ b/tests/unit/serializers/album-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('album', 'Unit | Serializer | album', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:album']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
The Home Route should fetch the recent releases from the Spotify API (`https://api.spotify.com/v1/browse/new-releases`), and display the albums.

We should serialize the data and display it.  