### PR TITLE
Media player's current time

### DIFF
--- a/app/components/media-player.js
+++ b/app/components/media-player.js
@@ -1,17 +1,9 @@
 import Component from '@ember/component';
-import { observer } from '@ember/object';
 
 export default Component.extend({
   tagName: 'audio',
   audioSource: 'http://www.kozco.com/tech/organfinale.mp3',
   attributeBindings: ['controls'],
-  songEnded: null,
-
-  songEndedUpdated: observer('songEnded', function() {
-    if (this.songEnded) {
-      this.set('shouldPlay', false);
-    }
-  }),
 
   togglePlay() {
     if (this.get('shouldPlay') === null) {
@@ -23,20 +15,18 @@ export default Component.extend({
     }
   },
 
-  completeSong() {
-    if (this.songEnded) {
-      this.togglePlay();
-    }
-  },
-
   didReceiveAttrs() {
     this.togglePlay();
   },
 
   didInsertElement() {
     this.element.onended = () => {
-      this.set('songEnded', true);
+      this.set('shouldPlay', false);
     };
-    this.set('songDuration', this.element.duration);
+
+    this.element.ontimeupdate = () => {
+      const time = this.element.currentTime;
+      this.set('currentTime', time)
+    }
   }
 });

--- a/app/components/now-playing-bar.js
+++ b/app/components/now-playing-bar.js
@@ -1,15 +1,10 @@
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
-import { formattedTime } from '../lib/format-time';
+import { get } from '@ember/object';
 
 export default Component.extend({
   tagName: 'div',
   shouldPlay: null,
   currentTime: null,
-
-  formattedCurrentTime: computed('currentTime', function () {
-    return formattedTime(this.currentTime);
-  }),
 
   actions: {
     togglePlay() {

--- a/app/components/now-playing-bar.js
+++ b/app/components/now-playing-bar.js
@@ -1,10 +1,15 @@
 import Component from '@ember/component';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
+import { formattedTime } from '../lib/format-time';
 
 export default Component.extend({
   tagName: 'div',
   shouldPlay: null,
-  songDuration: null,
+  currentTime: null,
+
+  formattedCurrentTime: computed('currentTime', function () {
+    return formattedTime(this.currentTime);
+  }),
 
   actions: {
     togglePlay() {

--- a/app/helpers/format-time.js
+++ b/app/helpers/format-time.js
@@ -1,3 +1,5 @@
+import { helper } from '@ember/component/helper';
+
 export function formattedHours(time) {
   if (time >= 10) {
     return `${time}:`
@@ -26,7 +28,7 @@ export function formattedSeconds(time) {
   }
 }
 
-export function formattedTime(time) {
+export function formatTime(time) {
   let hours = formattedHours(Math.round(time / 3600));
   let timeLeft = time % 3600;
 
@@ -37,3 +39,5 @@ export function formattedTime(time) {
 
   return `${hours}${minutes}${seconds}`
 }
+
+export default helper(formatTime);

--- a/app/helpers/format-time.js
+++ b/app/helpers/format-time.js
@@ -1,31 +1,26 @@
 import { helper } from '@ember/component/helper';
 
 export function formattedHours(time) {
-  if (time >= 10) {
-    return `${time}:`
-  } else if (time >= 1) {
-    return `0${time}:`;
+  if (time > 0) {
+    const hours = time.toString()
+    return `${hours.padStart(2, '0')}:`;
   } else {
-    return '';
+    return ''
   }
 }
 
 export function formattedMinutes(time) {
-  if (time < 1) {
-    return '0:'
-  } else if (time < 10) {
-    return `0${time}:`
+  if (time > 0) {
+    const minutes = time.toString();
+    return `${minutes.padStart(2, '0')}:`;
   } else {
-    return `${time}:`
+    return '0:'
   }
 }
 
 export function formattedSeconds(time) {
-  if (time > 9) {
-    return `${time}`;
-  } else {
-    return `0${time}`
-  }
+  const seconds = time.toString();
+  return `${seconds.padStart(2, '0')}`;
 }
 
 export function formatTime(time) {

--- a/app/lib/format-time.js
+++ b/app/lib/format-time.js
@@ -1,0 +1,39 @@
+export function formattedHours(time) {
+  if (time >= 10) {
+    return `${time}:`
+  } else if (time >= 1) {
+    return `0${time}:`;
+  } else {
+    return '';
+  }
+}
+
+export function formattedMinutes(time) {
+  if (time < 1) {
+    return '0:'
+  } else if (time < 10) {
+    return `0${time}:`
+  } else {
+    return `${time}:`
+  }
+}
+
+export function formattedSeconds(time) {
+  if (time > 9) {
+    return `${time}`;
+  } else {
+    return `0${time}`
+  }
+}
+
+export function formattedTime(time) {
+  let hours = formattedHours(Math.round(time / 3600));
+  let timeLeft = time % 3600;
+
+  let minutes = formattedMinutes(Math.round(timeLeft / 60));
+  timeLeft = timeLeft % 60;
+
+  let seconds = formattedSeconds(Math.round(timeLeft));
+
+  return `${hours}${minutes}${seconds}`
+}

--- a/app/models/album.js
+++ b/app/models/album.js
@@ -5,5 +5,5 @@ export default Model.extend({
   name: attr(),
   artists: attr(),
   images: attr(),
-  tracks: attr()
+  tracks: attr(),
 });

--- a/app/templates/components/now-playing-bar.hbs
+++ b/app/templates/components/now-playing-bar.hbs
@@ -6,14 +6,26 @@
       Play!
     {{/if}}
   </button>
-  <div class="song-duration">
+
+  {{!-- duration will come from the Spotify API --}}
+  {{!-- <div class="song-duration">
     Song Duration:
     {{#if songDuration}}
       {{songDuration}}
     {{else}}
       00:00
     {{/if}}
+  </div> --}}
+
+  <div class="current-time">
+    Current Time:
+    {{#if formattedCurrentTime}}
+      {{formattedCurrentTime}}
+    {{else}}
+      0:00
+    {{/if}}
   </div>
-  {{media-player shouldPlay=shouldPlay songDuration=songDuration}}
+
+  {{media-player shouldPlay=shouldPlay currentTime=currentTime}}
 </div>
 

--- a/app/templates/components/now-playing-bar.hbs
+++ b/app/templates/components/now-playing-bar.hbs
@@ -19,8 +19,8 @@
 
   <div class="current-time">
     Current Time:
-    {{#if formattedCurrentTime}}
-      {{formattedCurrentTime}}
+    {{#if currentTime}}
+      {{format-time currentTime}}
     {{else}}
       0:00
     {{/if}}

--- a/tests/integration/helpers/format-time-test.js
+++ b/tests/integration/helpers/format-time-test.js
@@ -1,0 +1,17 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('format-time', 'helper:format-time', {
+  integration: true
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{format-time inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '1234');
+});
+


### PR DESCRIPTION
Displays and formats the currrent time in a track. 

Looking ahead, I'll probably want to use my `lib/format-track.js` for formatting the duration for tracks on an album's page. 

Started to look into similar logic for a song's duration, but I think it'd be easier to get from the API. 

Also starting to think about how I'll pass a song into the Media Player. Work for next week might include creating a Song model that could hold the info I need for each track. I'd need it to include the audio source, duration, artist name, album, and album art probably. 

I think a good goal for next week is getting to where I can pass a song into the player. 
That'd feel the most "Spotifiy-y" up to this point. And would give me some things to style with!